### PR TITLE
Agregue la linea para reemplazar colons por _

### DIFF
--- a/src/export_tasks.py
+++ b/src/export_tasks.py
@@ -8,6 +8,7 @@ config_yaml = config()
 CLEAN_TASKS_LIST = CleanTasksDict().get_clean_tasks_list()
 FILE_NAME = config_yaml['file_name']
 NOW = str(datetime.now().isoformat()).split(".")[0]
+NOW = NOW.replace(":", "_")
 
 class ExportTasks():
     @staticmethod


### PR DESCRIPTION
Hay un error cuando se se envía como nombre de archivo a los métodos para convertir el dataframe a excel o a csv, que se soluciona reemplazando los caracteres colons (":") por otro que si admita el sistema de archivos del sistema operativo. Yo lo reemplacé por guión bajo ("_"). Es una corrección mínima pero que me llevó un toque de tiempo descrubrir.